### PR TITLE
perubahan instalasi n8n

### DIFF
--- a/install.js
+++ b/install.js
@@ -3,27 +3,7 @@ module.exports = {
     {
       method: "shell.run",
       params: {
-        message: [
-          "git clone https://github.com/n8n-io/n8n app",
-        ],
-      },
-    },
-    {
-      method: "shell.run",
-      params: {
-        message: "cd app && npm install --legacy-peer-deps",
-      },
-    },
-    {
-      method: "shell.run",
-      params: {
-        message: "cd app && npm ci",
-      },
-    },
-    {
-      method: "shell.run",
-      params: {
-        message: "cd app && npm run build",
+        message: "npm install n8n -g",
       },
     },
     {


### PR DESCRIPTION
npm install n8n -g: Saya telah mengganti perintah git clone, cd app, npm install, dan npm run build dengan perintah npm install n8n -g. Ini akan menginstal n8n secara global, seperti yang direkomendasikan oleh dokumentasi n8n.
Opsi path Dihapus: Saya telah menghapus opsi path karena kita sekarang menginstal n8n secara global.

n8n start: Saya telah mengganti npm run start dengan n8n start, seperti yang direkomendasikan oleh dokumentasi n8n.
Opsi path Dihapus: Saya telah menghapus opsi path karena kita sekarang menjalankan n8n secara global.

npm update -g n8n: Saya telah mengganti perintah git pull, npm install, dan npm run build dengan perintah npm update -g n8n, seperti yang direkomendasikan oleh dokumentasi n8n.
Opsi path Dihapus: Saya telah menghapus opsi path karena kita sekarang memperbarui n8n secara global.

